### PR TITLE
fix(settings): align account backup imports

### DIFF
--- a/src/lib/utils/account-import-utils.test.ts
+++ b/src/lib/utils/account-import-utils.test.ts
@@ -25,6 +25,12 @@ describe('imported account activation name', () => {
   it('returns undefined when the imported backup has no account name', () => {
     expect(getImportedAccountActiveName(undefined, [])).toBeUndefined();
   });
+
+  it('tolerates account entries the hooks store has not hydrated yet', () => {
+    const accounts = [{ name: 'Account dress' }, undefined] as unknown as Array<{ name?: string }>;
+
+    expect(getImportedAccountActiveName('Account dress', accounts)).toBe('Account dress 2');
+  });
 });
 
 describe('imported account metadata', () => {
@@ -187,5 +193,38 @@ describe('account import PKC options', () => {
 
     expect(result.account.pkcOptions.libp2pJsClientsOptions).toEqual([{ key: 'libp2pjs', options: { bootstrap: ['custom-peer'] } }]);
     expect(result.account.pkcOptions.resolveAuthorAddresses).toBe(true);
+  });
+
+  it('preserves the backup router list when an electron import falls back to platform defaults', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({ account: { pkcOptions: { pubsubKuboRpcClientsOptions: ['https://pubsub.example'], httpRoutersOptions: ['https://custom.example'] } } }),
+        true,
+      ),
+    );
+
+    expect(result.account.pkcOptions.pkcRpcClientsOptions).toEqual(['ws://localhost:9138']);
+    expect(result.account.pkcOptions.httpRoutersOptions).toEqual(['https://custom.example']);
+  });
+
+  it('keeps a remote rpc endpoint that sits alongside a localhost entry', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({
+          account: { pkcOptions: { pkcRpcClientsOptions: ['ws://localhost:9138', 'wss://remote.example'], httpRoutersOptions: ['https://custom.example'] } },
+        }),
+        false,
+        browserWindow,
+      ),
+    );
+
+    expect(result.account.pkcOptions.pkcRpcClientsOptions).toEqual(['ws://localhost:9138', 'wss://remote.example']);
+    expect(result.account.pkcOptions.httpRoutersOptions).toEqual(['https://custom.example']);
+  });
+
+  it('falls back to platform defaults when the backup carries a non-object pkcOptions', () => {
+    const result = JSON.parse(processImportedAccount(JSON.stringify({ account: { pkcOptions: 'ws://localhost:9138' } }), true));
+
+    expect(result.account.pkcOptions).toEqual(getDefaultElectronConfig());
   });
 });

--- a/src/lib/utils/account-import-utils.test.ts
+++ b/src/lib/utils/account-import-utils.test.ts
@@ -1,5 +1,76 @@
 import { describe, expect, it } from 'vitest';
-import { getDefaultElectronConfig, getDefaultWebConfig, processImportedAccount } from './account-import-utils';
+import {
+  getDefaultElectronConfig,
+  getDefaultWebConfig,
+  getImportedAccountActiveName,
+  processImportedAccount,
+  readImportedAccountAddresses,
+  rememberImportedAccountAddress,
+} from './account-import-utils';
+import { shouldUpgradeBrowserPureP2PAccount } from '../p2p-runtime';
+
+const browserWindow = {} as Window;
+
+describe('imported account activation name', () => {
+  it('uses the imported name when it is available', () => {
+    expect(getImportedAccountActiveName('Account dress', [{ name: 'Account stitch' }])).toBe('Account dress');
+  });
+
+  it('uses the next available suffix when the imported name exists', () => {
+    const accounts = [{ name: 'Account dress' }, { name: 'Account dress 2' }, { name: 'Account dress 3' }];
+
+    expect(getImportedAccountActiveName('Account dress', accounts)).toBe('Account dress 4');
+  });
+
+  it('returns undefined when the imported backup has no account name', () => {
+    expect(getImportedAccountActiveName(undefined, [])).toBeUndefined();
+  });
+});
+
+describe('imported account metadata', () => {
+  it('rejects invalid backup shapes before calling hooks', () => {
+    expect(() => processImportedAccount('null', false, browserWindow)).toThrow('Account backup must be a JSON object.');
+    expect(() => processImportedAccount('{}', false, browserWindow)).toThrow('Account backup is missing account data.');
+  });
+
+  it('preserves legacy, short-address, and custom account names', () => {
+    for (const name of ['Account 1', 'Account dress', 'Personal']) {
+      const result = JSON.parse(processImportedAccount(JSON.stringify({ account: { name } }), false, browserWindow));
+      expect(result.account.name).toBe(name);
+    }
+  });
+
+  it('merges owned communities into subscriptions without duplicates', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({
+          account: {
+            communities: { 'business.eth': {}, 'music.bso': {} },
+            subscriptions: ['business.eth', 'technology.bso'],
+          },
+        }),
+        false,
+        browserWindow,
+      ),
+    );
+
+    expect(result.account.subscriptions).toEqual(['business.eth', 'technology.bso', 'music.bso']);
+  });
+
+  it('tracks every imported address while maintaining the legacy latest-address key', () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    rememberImportedAccountAddress('address-1', storage);
+    rememberImportedAccountAddress('address-2', storage);
+
+    expect(readImportedAccountAddresses(storage)).toEqual(['address-1', 'address-2']);
+    expect(storage.getItem('importedAccountAddress')).toBe('address-2');
+  });
+});
 
 describe('account import PKC options', () => {
   it('includes only supported chain providers in platform defaults', () => {
@@ -24,7 +95,7 @@ describe('account import PKC options', () => {
       },
     };
 
-    const result = JSON.parse(processImportedAccount(JSON.stringify(importedAccount), false));
+    const result = JSON.parse(processImportedAccount(JSON.stringify(importedAccount), false, browserWindow));
 
     expect(result.account.chainProviders).toEqual({
       eth: { urls: ['https://eth.example'], chainId: 1 },
@@ -67,6 +138,7 @@ describe('account import PKC options', () => {
           },
         }),
         false,
+        browserWindow,
       ),
     );
 
@@ -78,13 +150,42 @@ describe('account import PKC options', () => {
       processImportedAccount(
         JSON.stringify({ account: { pkcOptions: { pubsubKuboRpcClientsOptions: ['https://pubsub.example'], httpRoutersOptions: ['https://custom.example'] } } }),
         false,
+        browserWindow,
       ),
     );
     const emptyRouters = JSON.parse(
-      processImportedAccount(JSON.stringify({ account: { pkcOptions: { pubsubKuboRpcClientsOptions: ['https://pubsub.example'], httpRoutersOptions: [] } } }), false),
+      processImportedAccount(
+        JSON.stringify({ account: { pkcOptions: { pubsubKuboRpcClientsOptions: ['https://pubsub.example'], httpRoutersOptions: [] } } }),
+        false,
+        browserWindow,
+      ),
     );
 
     expect(customRouters.account.pkcOptions.httpRoutersOptions).toEqual(['https://custom.example']);
     expect(emptyRouters.account.pkcOptions.httpRoutersOptions).toEqual([]);
+    expect(customRouters.account.pkcOptions.libp2pJsClientsOptions).toEqual([{ key: 'libp2pjs' }]);
+    expect(customRouters.account.pkcOptions.pubsubKuboRpcClientsOptions).toBeUndefined();
+    expect(shouldUpgradeBrowserPureP2PAccount(customRouters.account, browserWindow)).toBe(false);
+  });
+
+  it('preserves an already-modern browser libp2p configuration', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({
+          account: {
+            pkcOptions: {
+              libp2pJsClientsOptions: [{ key: 'libp2pjs', options: { bootstrap: ['custom-peer'] } }],
+              httpRoutersOptions: ['https://custom.example'],
+              resolveAuthorAddresses: true,
+            },
+          },
+        }),
+        false,
+        browserWindow,
+      ),
+    );
+
+    expect(result.account.pkcOptions.libp2pJsClientsOptions).toEqual([{ key: 'libp2pjs', options: { bootstrap: ['custom-peer'] } }]);
+    expect(result.account.pkcOptions.resolveAuthorAddresses).toBe(true);
   });
 });

--- a/src/lib/utils/account-import-utils.ts
+++ b/src/lib/utils/account-import-utils.ts
@@ -66,7 +66,7 @@ export const getImportedAccountActiveName = (importedAccountName: string | undef
     return undefined;
   }
 
-  const accountNames = new Set(accounts.map((account) => account.name));
+  const accountNames = new Set(accounts.map((account) => account?.name));
   if (!accountNames.has(importedAccountName)) {
     return importedAccountName;
   }
@@ -112,10 +112,11 @@ const isLocalhostRpc = (url: string): boolean => {
   return url.includes('localhost') || url.includes('127.0.0.1');
 };
 
-// Check if account has non-localhost RPC configuration
+// Check if account has at least one non-localhost RPC endpoint. A mixed list counts, so importing never
+// discards a reachable remote node just because a localhost entry sits alongside it.
 const hasNonLocalhostRpc = (options: PkcOptions): boolean => {
   const hasRpcOptions = (options.pkcRpcClientsOptions?.length ?? 0) > 0;
-  return hasRpcOptions && !options.pkcRpcClientsOptions?.some(isLocalhostRpc);
+  return hasRpcOptions && (options.pkcRpcClientsOptions?.some((url) => !isLocalhostRpc(url)) ?? false);
 };
 
 // Check if account has pubsub providers configured
@@ -205,6 +206,12 @@ export const processImportedAccount = (accountJson: string, isElectron: boolean,
     const subscriptions = Array.isArray(importedAccount.account.subscriptions) ? importedAccount.account.subscriptions : [];
     importedAccount.account.subscriptions = [...new Set([...subscriptions, ...Object.keys(importedAccount.account.communities)])];
   }
+  const importedPkcOptions: unknown = importedAccount.account.pkcOptions;
+  if (importedPkcOptions && (typeof importedPkcOptions !== 'object' || Array.isArray(importedPkcOptions))) {
+    // A hand-edited backup can carry a non-object pkcOptions; drop it so platform defaults apply instead
+    // of assigning properties onto a primitive, which throws in strict mode.
+    importedAccount.account.pkcOptions = undefined;
+  }
   const explicitImportedHttpRoutersOptions = importedAccount.account.pkcOptions?.httpRoutersOptions;
 
   if (importedAccount.account.chainProviders) {
@@ -216,20 +223,26 @@ export const processImportedAccount = (accountJson: string, isElectron: boolean,
   }
 
   // Transform pkcOptions based on platform and existing config
+  let normalizedPkcOptions: PkcOptions;
   if (importedAccount.account.pkcOptions) {
-    importedAccount.account.pkcOptions = transformPkcOptionsForImport(importedAccount, isElectron);
+    normalizedPkcOptions = transformPkcOptionsForImport(importedAccount, isElectron);
   } else {
     // If no pkcOptions exist, set defaults based on platform
-    importedAccount.account.pkcOptions = isElectron ? getDefaultElectronConfig() : getDefaultWebConfig();
+    normalizedPkcOptions = isElectron ? getDefaultElectronConfig() : getDefaultWebConfig();
   }
+  importedAccount.account.pkcOptions = normalizedPkcOptions;
 
   const browserWindow = targetWindow ?? (typeof window === 'undefined' ? undefined : window);
   if (!isElectron && browserWindow && shouldUpgradeBrowserPureP2PAccount(importedAccount.account, browserWindow)) {
-    importedAccount.account.pkcOptions = {
-      ...getBrowserPureP2PAccountOptions(importedAccount.account),
-      ...(Array.isArray(explicitImportedHttpRoutersOptions) ? { httpRoutersOptions: explicitImportedHttpRoutersOptions } : {}),
-    };
+    normalizedPkcOptions = getBrowserPureP2PAccountOptions(importedAccount.account);
   }
+
+  // Platform defaults and the pure-P2P upgrade both replace the whole options object, so restore the backup's
+  // explicit router list last; otherwise importing on Electron silently drops custom routers.
+  if (Array.isArray(explicitImportedHttpRoutersOptions)) {
+    normalizedPkcOptions.httpRoutersOptions = explicitImportedHttpRoutersOptions;
+  }
+  importedAccount.account.pkcOptions = normalizedPkcOptions;
 
   return JSON.stringify(importedAccount);
 };

--- a/src/lib/utils/account-import-utils.ts
+++ b/src/lib/utils/account-import-utils.ts
@@ -1,8 +1,12 @@
 import { getSupportedChainProviders } from './chain-provider-utils';
+import { getBrowserPureP2PAccountOptions, shouldUpgradeBrowserPureP2PAccount } from '../p2p-runtime';
 
 interface PkcOptions {
   ipfsGatewayUrls?: string[];
+  kuboRpcClientsOptions?: unknown[];
+  libp2pJsClientsOptions?: unknown[];
   pubsubKuboRpcClientsOptions?: string[];
+  pubsubHttpClientsOptions?: unknown[];
   pkcRpcClientsOptions?: string[];
   httpRoutersOptions?: string[];
   chainProviders?: {
@@ -13,16 +17,66 @@ interface PkcOptions {
   };
   resolveAuthorAddresses?: boolean;
   validatePages?: boolean;
+  [key: string]: unknown;
 }
 
 interface ImportedAccount {
   account?: {
+    author?: { address?: string };
     chainProviders?: PkcOptions['chainProviders'];
+    communities?: Record<string, unknown>;
+    name?: string;
     pkcOptions?: PkcOptions;
-    [key: string]: any;
+    subscriptions?: string[];
+    [key: string]: unknown;
   };
-  [key: string]: any;
+  [key: string]: unknown;
 }
+
+const IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY = 'importedAccountAddresses';
+const IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY = 'importedAccountAddress';
+
+export const readImportedAccountAddresses = (storage: Pick<Storage, 'getItem'> = localStorage): string[] => {
+  try {
+    const storedAddresses = storage.getItem(IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY);
+    const parsedAddresses: unknown = storedAddresses ? JSON.parse(storedAddresses) : null;
+    const normalizedAddresses = Array.isArray(parsedAddresses)
+      ? parsedAddresses.filter((address): address is string => typeof address === 'string' && address.length > 0)
+      : [];
+    const legacyAddress = storage.getItem(IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY);
+    return [...new Set(legacyAddress ? [...normalizedAddresses, legacyAddress] : normalizedAddresses)];
+  } catch (error) {
+    console.warn('Failed to read imported account addresses from localStorage:', error);
+    return [];
+  }
+};
+
+export const rememberImportedAccountAddress = (address: string, storage: Pick<Storage, 'getItem' | 'setItem'> = localStorage) => {
+  try {
+    const importedAddresses = readImportedAccountAddresses(storage);
+    storage.setItem(IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY, JSON.stringify([...new Set([...importedAddresses, address])]));
+    storage.setItem(IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY, address);
+  } catch (error) {
+    console.warn('Failed to save imported account address to localStorage:', error);
+  }
+};
+
+export const getImportedAccountActiveName = (importedAccountName: string | undefined, accounts: Array<{ name?: string }>): string | undefined => {
+  if (!importedAccountName) {
+    return undefined;
+  }
+
+  const accountNames = new Set(accounts.map((account) => account.name));
+  if (!accountNames.has(importedAccountName)) {
+    return importedAccountName;
+  }
+
+  let suffix = 2;
+  while (accountNames.has(`${importedAccountName} ${suffix}`)) {
+    suffix += 1;
+  }
+  return `${importedAccountName} ${suffix}`;
+};
 
 // Default configuration for web/mobile platforms
 export const getDefaultWebConfig = (): PkcOptions => ({
@@ -68,6 +122,8 @@ const hasNonLocalhostRpc = (options: PkcOptions): boolean => {
 const hasPubsubProviders = (options: PkcOptions): boolean => {
   return (options.pubsubKuboRpcClientsOptions?.length ?? 0) > 0 || (options.ipfsGatewayUrls?.length ?? 0) > 0;
 };
+
+const hasBrowserLibp2pProvider = (options: PkcOptions): boolean => (options.libp2pJsClientsOptions?.length ?? 0) > 0;
 
 // Check if account has localhost RPC configured
 const hasLocalhostRpc = (options: PkcOptions): boolean => {
@@ -120,8 +176,8 @@ export const transformPkcOptionsForImport = (importedAccount: ImportedAccount, i
     if (hasLocalhostRpc(currentOptions)) {
       return getPlatformDefaults();
     }
-    // If no RPC or has pubsub providers, use web defaults
-    return (currentOptions.pubsubKuboRpcClientsOptions?.length ?? 0) > 0 ? currentOptions : getPlatformDefaults();
+    // Preserve both current browser transports; missing transports use web defaults.
+    return hasBrowserLibp2pProvider(currentOptions) || hasPubsubProviders(currentOptions) ? currentOptions : getPlatformDefaults();
   }
 };
 
@@ -129,19 +185,27 @@ export const transformPkcOptionsForImport = (importedAccount: ImportedAccount, i
  * Processes an imported account by transforming its PKC options
  * Returns the modified account as a JSON string ready for import
  */
-export const processImportedAccount = (accountJson: string, isElectron: boolean): string => {
-  let importedAccount;
+export const processImportedAccount = (accountJson: string, isElectron: boolean, targetWindow?: Window): string => {
+  let importedAccount: ImportedAccount;
 
   try {
-    importedAccount = JSON.parse(accountJson);
+    const parsedAccount: unknown = JSON.parse(accountJson);
+    if (!parsedAccount || typeof parsedAccount !== 'object' || Array.isArray(parsedAccount)) {
+      throw new Error('Account backup must be a JSON object.');
+    }
+    importedAccount = parsedAccount as ImportedAccount;
   } catch (error) {
     throw new Error(`Failed to parse account data: ${error instanceof Error ? error.message : 'Unknown parsing error'}`);
   }
 
-  // Ensure account object exists
-  if (!importedAccount.account) {
-    importedAccount.account = {};
+  if (!importedAccount.account || typeof importedAccount.account !== 'object' || Array.isArray(importedAccount.account)) {
+    throw new Error('Account backup is missing account data.');
   }
+  if (importedAccount.account.communities) {
+    const subscriptions = Array.isArray(importedAccount.account.subscriptions) ? importedAccount.account.subscriptions : [];
+    importedAccount.account.subscriptions = [...new Set([...subscriptions, ...Object.keys(importedAccount.account.communities)])];
+  }
+  const explicitImportedHttpRoutersOptions = importedAccount.account.pkcOptions?.httpRoutersOptions;
 
   if (importedAccount.account.chainProviders) {
     importedAccount.account.chainProviders = getSupportedChainProviders(importedAccount.account.chainProviders);
@@ -157,6 +221,14 @@ export const processImportedAccount = (accountJson: string, isElectron: boolean)
   } else {
     // If no pkcOptions exist, set defaults based on platform
     importedAccount.account.pkcOptions = isElectron ? getDefaultElectronConfig() : getDefaultWebConfig();
+  }
+
+  const browserWindow = targetWindow ?? (typeof window === 'undefined' ? undefined : window);
+  if (!isElectron && browserWindow && shouldUpgradeBrowserPureP2PAccount(importedAccount.account, browserWindow)) {
+    importedAccount.account.pkcOptions = {
+      ...getBrowserPureP2PAccountOptions(importedAccount.account),
+      ...(Array.isArray(explicitImportedHttpRoutersOptions) ? { httpRoutersOptions: explicitImportedHttpRoutersOptions } : {}),
+    };
   }
 
   return JSON.stringify(importedAccount);

--- a/src/views/settings/account-settings/account-settings.test.tsx
+++ b/src/views/settings/account-settings/account-settings.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AccountSettings from './account-settings';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+const act = (React as { act?: (callback: () => void | Promise<void>) => void | Promise<void> }).act as (callback: () => void | Promise<void>) => void | Promise<void>;
+
+const hookMocks = vi.hoisted(() => ({
+  deleteAccount: vi.fn(),
+  exportAccount: vi.fn(),
+  importAccount: vi.fn(),
+  setActiveAccount: vi.fn(),
+  useAccount: vi.fn(),
+  useAccounts: vi.fn(),
+}));
+
+const fileReaderState = vi.hoisted(() => ({ result: '' as unknown }));
+
+vi.mock('@bitsocial/bitsocial-react-hooks', () => ({
+  deleteAccount: hookMocks.deleteAccount,
+  exportAccount: hookMocks.exportAccount,
+  importAccount: hookMocks.importAccount,
+  setActiveAccount: hookMocks.setActiveAccount,
+  useAccount: hookMocks.useAccount,
+  useAccounts: hookMocks.useAccounts,
+}));
+
+vi.mock('react-i18next', async () => {
+  const ReactModule = await import('react');
+  return {
+    Trans: ({ components, i18nKey }: { components?: Record<number, React.ReactElement>; i18nKey: string }) => {
+      const component = components?.[1];
+      return component ? ReactModule.cloneElement(component, {}, i18nKey) : ReactModule.createElement('span', null, i18nKey);
+    },
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+vi.mock('react-router-dom', async () => {
+  const ReactModule = await import('react');
+  return {
+    Link: ({ children }: { children?: React.ReactNode }) => ReactModule.createElement('a', null, children),
+  };
+});
+
+class MockFileReader {
+  onload: ((event: { target: { result: unknown } }) => void) | null = null;
+  result: unknown = null;
+
+  readAsText() {
+    this.result = fileReaderState.result;
+    this.onload?.({ target: { result: this.result } });
+  }
+}
+
+const createStorage = () => {
+  const values = new Map<string, string>();
+  return {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => [...values.keys()][index] ?? null,
+    get length() {
+      return values.size;
+    },
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  } satisfies Storage;
+};
+
+let root: Root;
+let container: HTMLDivElement;
+let createdInput: HTMLInputElement | null;
+let createElementSpy: ReturnType<typeof vi.spyOn>;
+let inputClickSpy: ReturnType<typeof vi.spyOn>;
+let alertSpy: ReturnType<typeof vi.spyOn>;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let reloadMock: ReturnType<typeof vi.fn>;
+const originalLocation = window.location;
+
+const render = () => {
+  act(() => root.render(createElement(AccountSettings)));
+};
+
+const getImportButton = () => {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent === 'import_account_backup');
+  if (!button) throw new Error('Import account backup button not found');
+  return button;
+};
+
+const selectImportFile = async () => {
+  await act(async () => {
+    getImportButton().click();
+  });
+  const file = new File(['{}'], 'account.json', { type: 'application/json' });
+  await act(async () => {
+    await createdInput?.onchange?.({ target: { files: [file] } } as unknown as Event);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('AccountSettings account import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('localStorage', createStorage());
+    fileReaderState.result = '';
+    createdInput = null;
+    window.electronApi = undefined;
+    window.isElectron = false;
+    hookMocks.useAccount.mockReturnValue({ id: 'current-id', name: 'Account current', author: { shortAddress: 'current' } });
+    hookMocks.useAccounts.mockReturnValue({
+      accounts: [
+        { id: 'current-id', name: 'Account current', author: { shortAddress: 'current' } },
+        { id: 'imported-id', name: 'Account dress', author: { shortAddress: 'dress' } },
+        { id: 'imported-2-id', name: 'Account dress 2', author: { shortAddress: 'dress' } },
+      ],
+      state: 'succeeded',
+    });
+    hookMocks.importAccount.mockResolvedValue(undefined);
+    hookMocks.setActiveAccount.mockResolvedValue(undefined);
+
+    vi.stubGlobal('FileReader', MockFileReader);
+    reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadMock },
+    });
+    alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    inputClickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => undefined);
+
+    const originalCreateElement = document.createElement.bind(document);
+    createElementSpy = vi.spyOn(document, 'createElement').mockImplementation(((tagName: string, options?: ElementCreationOptions) => {
+      const element = originalCreateElement(tagName, options);
+      if (tagName === 'input') createdInput = element as HTMLInputElement;
+      return element;
+    }) as typeof document.createElement);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) act(() => root.unmount());
+    container?.remove();
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+    createElementSpy?.mockRestore();
+    inputClickSpy?.mockRestore();
+    alertSpy?.mockRestore();
+    consoleLogSpy?.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('imports, normalizes, records, and activates the next available account name without reloading', async () => {
+    fileReaderState.result = JSON.stringify({
+      account: {
+        id: 'backup-id',
+        name: 'Account dress',
+        author: { address: 'address-dress' },
+        communities: { 'music.bso': {} },
+        pkcOptions: { pubsubKuboRpcClientsOptions: ['https://pubsub.example'] },
+      },
+    });
+
+    render();
+    await selectImportFile();
+
+    expect(hookMocks.importAccount).toHaveBeenCalledOnce();
+    const importedPayload = JSON.parse(hookMocks.importAccount.mock.calls[0][0]);
+    expect(importedPayload.account.subscriptions).toEqual(['music.bso']);
+    expect(importedPayload.account.pkcOptions.libp2pJsClientsOptions).toEqual([{ key: 'libp2pjs' }]);
+    expect(hookMocks.setActiveAccount).toHaveBeenCalledWith('Account dress 3');
+    expect(localStorage.getItem('importedAccountAddresses')).toBe(JSON.stringify(['address-dress']));
+    expect(localStorage.getItem('importedAccountAddress')).toBe('address-dress');
+    expect(alertSpy).toHaveBeenCalledWith('Imported Account dress 3');
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('disables importing until the hooks account store is ready', () => {
+    hookMocks.useAccounts.mockReturnValue({ accounts: [], state: 'initializing' });
+
+    render();
+
+    expect(getImportButton().disabled).toBe(true);
+  });
+
+  it('surfaces malformed backup JSON without importing', async () => {
+    fileReaderState.result = '{bad json';
+
+    render();
+    await selectImportFile();
+
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to parse account data:'));
+    expect(hookMocks.importAccount).not.toHaveBeenCalled();
+  });
+
+  it('does not record or activate the account when hooks import fails', async () => {
+    fileReaderState.result = JSON.stringify({ account: { id: 'backup-id', name: 'Account dress', author: { address: 'address-dress' } } });
+    hookMocks.importAccount.mockRejectedValue(new Error('import failed'));
+
+    render();
+    await selectImportFile();
+
+    expect(alertSpy).toHaveBeenCalledWith('import failed');
+    expect(hookMocks.setActiveAccount).not.toHaveBeenCalled();
+    expect(localStorage.getItem('importedAccountAddress')).toBeNull();
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/settings/account-settings/account-settings.tsx
+++ b/src/views/settings/account-settings/account-settings.tsx
@@ -2,14 +2,16 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import { deleteAccount, exportAccount, importAccount, setActiveAccount, useAccount, useAccounts } from '@bitsocial/bitsocial-react-hooks';
-import { processImportedAccount } from '../../../lib/utils/account-import-utils';
+import { getImportedAccountActiveName, processImportedAccount, rememberImportedAccountAddress } from '../../../lib/utils/account-import-utils';
 import { exportFile } from '../../../lib/utils/file-export-utils';
 import styles from './account-settings.module.css';
 import { getDisplayAddress } from '../../../lib/utils/address-utils';
 import { getEditableAccountData } from '../../../lib/utils/account-data-utils';
+import { isElectronRuntime } from '../../../lib/p2p-browser-config';
 
 const ImportAccountButton = () => {
-  const isElectron = window.electronApi?.isElectron === true;
+  const isElectron = isElectronRuntime(window);
+  const { accounts, state: accountsState } = useAccounts();
 
   const handleImportAccount = async () => {
     const fileInput = document.createElement('input');
@@ -29,27 +31,27 @@ const ImportAccountButton = () => {
         const reader = new FileReader();
         reader.onload = async (e) => {
           try {
-            const fileContent = e.target!.result;
+            const fileContent = e.target?.result ?? reader.result;
             if (typeof fileContent !== 'string') {
               throw new Error('File content is not a string.');
             }
             // Process the imported account with platform-appropriate PKC options.
             const transformedAccountString = processImportedAccount(fileContent, isElectron);
             const newAccount = JSON.parse(transformedAccountString);
+            const importedAccountActiveName = getImportedAccountActiveName(newAccount.account?.name, accounts);
             await importAccount(transformedAccountString);
 
             // Store the imported account's address
             if (newAccount.account?.author?.address) {
-              localStorage.setItem('importedAccountAddress', newAccount.account.author.address);
+              rememberImportedAccountAddress(newAccount.account.author.address);
             }
 
-            // Set the new account as active before reloading
-            if (newAccount.account?.name) {
-              await setActiveAccount(newAccount.account.name);
+            // Hooks suffix duplicate account names during import, so activate the same resolved name.
+            if (importedAccountActiveName) {
+              await setActiveAccount(importedAccountActiveName);
             }
 
-            alert(`Imported ${newAccount.account?.name}`);
-            window.location.reload();
+            alert(`Imported ${importedAccountActiveName}`);
           } catch (error) {
             if (error instanceof Error) {
               alert(error.message);
@@ -78,7 +80,7 @@ const ImportAccountButton = () => {
     <Trans
       i18nKey='import_account_backup'
       components={{
-        1: <button key='importAccountButton' type='button' onClick={handleImportAccount} />,
+        1: <button key='importAccountButton' type='button' disabled={accountsState !== 'succeeded'} onClick={handleImportAccount} />,
       }}
     />
   );


### PR DESCRIPTION
## Summary

- normalize account backups consistently with 5chan while preserving legacy, short-address, and custom names
- choose the next available account-name suffix, retain imported address metadata, and avoid a page reload after activation
- preserve compatible browser transport and chain-provider settings and gate import until the accounts store is ready

## Verification

- 290 Vitest tests passed
- build, lint, type-check, Knip, and changed-scope React Doctor passed
- Chrome, Firefox, and WebKit desktop/mobile import flows passed
- throttled Chromium confirmed the import readiness gate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how imported accounts are normalized and activated, including PKC/RPC and browser transport selection—misconfiguration could affect connectivity, though behavior is heavily covered by new tests.
> 
> **Overview**
> Aligns **account backup import** with stricter normalization, correct activation naming, and safer networking defaults—without forcing a full page reload.
> 
> **Import pipeline (`account-import-utils`)** now validates backup shape early, merges owned **communities** into **subscriptions**, and tracks imported author addresses in both a new list key and the legacy `importedAccountAddress` entry. **`getImportedAccountActiveName`** picks the next free suffix when the backup name already exists (matching hooks behavior). PKC handling preserves **mixed localhost + remote RPC** lists, treats invalid `pkcOptions` as missing, keeps explicit **http router** lists after platform or **browser pure-P2P** upgrades, and on web preserves **libp2p** transports alongside pubsub defaults.
> 
> **Account settings UI** gates the import button until `useAccounts` has succeeded, resolves the active name before `setActiveAccount`, records addresses via **`rememberImportedAccountAddress`**, uses **`isElectronRuntime`**, and completes import with an alert only—**no `location.reload`**. Malformed JSON or failed hook imports no longer leave partial localStorage or wrong active accounts.
> 
> Coverage adds unit tests for the new helpers and PKC edge cases, plus jsdom tests for the full import button flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849b1426cedc79646dcea1fbe457ef86d019ac86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved account backup imports with validation, name preservation, subscription merging, and imported-address tracking.
  * Preserved compatible browser and remote networking settings during imports.
  * Account imports now complete without forcing a page reload.
  * Import controls remain disabled until account data is ready.

* **Bug Fixes**
  * Improved handling of malformed backups and import failures.
  * Prevented duplicate account names from being activated incorrectly.
  * Added more reliable file-reading behavior across browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->