### PR TITLE
fix(votes): abandon vote publications with hooks 0.1.44 and keep navigation after abandoned posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "packageManager": "yarn@4.17.1",
   "dependencies": {
-    "@bitsocial/bitsocial-react-hooks": "0.1.42",
+    "@bitsocial/bitsocial-react-hooks": "0.1.44",
     "@bitsocial/bso-resolver": "0.0.10",
     "@capacitor/app": "7.0.1",
     "@capacitor/filesystem": "7.1.4",

--- a/src/hooks/use-downvote.ts
+++ b/src/hooks/use-downvote.ts
@@ -1,11 +1,10 @@
 import { useMemo } from 'react';
-import { ChallengeVerification, Comment, usePublishVote, useAccountVote } from '@bitsocial/bitsocial-react-hooks';
+import { ChallengeVerification, Comment, useAccountVote } from '@bitsocial/bitsocial-react-hooks';
+import usePublishVoteWithChallengeAbandon from './use-publish-vote-with-challenge-abandon';
 import { alertChallengeVerificationFailed } from '../lib/utils/challenge-utils';
 import { getCommentCommunityAddress } from '../lib/utils/comment-utils';
-import useChallengesStore from '../stores/use-challenges-store';
 
 const useDownvote = (comment: Comment): [boolean, () => void] => {
-  const { addChallenge } = useChallengesStore();
   const { vote } = useAccountVote({ commentCid: comment?.cid });
 
   const publishVoteOptions = useMemo(
@@ -13,12 +12,6 @@ const useDownvote = (comment: Comment): [boolean, () => void] => {
       commentCid: comment?.cid,
       vote: vote !== -1 ? -1 : 0,
       communityAddress: getCommentCommunityAddress(comment),
-      onChallenge: (...args: any) => {
-        return new Promise<void>((resolve) => {
-          addChallenge([...args, comment]);
-          resolve();
-        });
-      },
       onChallengeVerification: (challengeVerification: ChallengeVerification, publication: any) =>
         new Promise<void>((resolve) => {
           alertChallengeVerificationFailed(challengeVerification, publication);
@@ -29,9 +22,9 @@ const useDownvote = (comment: Comment): [boolean, () => void] => {
         alert(error.message);
       },
     }),
-    [comment, vote, addChallenge],
+    [comment, vote],
   );
-  const { publishVote } = usePublishVote(publishVoteOptions);
+  const { publishVote } = usePublishVoteWithChallengeAbandon(publishVoteOptions, comment);
 
   return [vote === -1, publishVote];
 };

--- a/src/hooks/use-publish-vote-with-challenge-abandon.test.tsx
+++ b/src/hooks/use-publish-vote-with-challenge-abandon.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import * as React from 'react';
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import usePublishVoteWithChallengeAbandon from './use-publish-vote-with-challenge-abandon';
+import useChallengesStore from '../stores/use-challenges-store';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+const act = (React as { act?: (callback: () => void | Promise<void>) => void | Promise<void> }).act as (callback: () => void | Promise<void>) => void | Promise<void>;
+
+const testState = vi.hoisted(() => ({
+  abandonPublish: vi.fn().mockResolvedValue(undefined),
+  publishVote: vi.fn().mockResolvedValue(undefined),
+  lastOptions: undefined as Record<string, any> | undefined,
+}));
+
+vi.mock('@bitsocial/bitsocial-react-hooks', () => ({
+  usePublishVote: (options: Record<string, any>) => {
+    testState.lastOptions = options;
+    return { abandonPublish: testState.abandonPublish, publishVote: testState.publishVote };
+  },
+}));
+
+const comment = { cid: 'comment-cid' } as any;
+const publishVoteOptions = { commentCid: 'comment-cid', vote: 1 };
+
+let container: HTMLDivElement;
+let latestValue: ReturnType<typeof usePublishVoteWithChallengeAbandon>;
+let root: Root;
+
+const HookHarness = () => {
+  latestValue = usePublishVoteWithChallengeAbandon(publishVoteOptions, comment);
+  return null;
+};
+
+describe('usePublishVoteWithChallengeAbandon', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testState.abandonPublish = vi.fn().mockResolvedValue(undefined);
+    testState.lastOptions = undefined;
+    useChallengesStore.setState({ challenges: [] });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root.render(createElement(HookHarness)));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    useChallengesStore.setState({ challenges: [] });
+  });
+
+  it('returns the usePublishVote result and forwards the publish options', () => {
+    expect(latestValue.publishVote).toBe(testState.publishVote);
+    expect(latestValue.abandonPublish).toBe(testState.abandonPublish);
+    expect(testState.lastOptions).toMatchObject(publishVoteOptions);
+  });
+
+  it('adds the challenge with the voted comment appended for the challenge modal preview', async () => {
+    const challenge = { challenges: [] };
+    const votePublication = { vote: 1 };
+    await act(async () => {
+      await testState.lastOptions?.onChallenge(challenge, votePublication);
+    });
+
+    const challenges = useChallengesStore.getState().challenges;
+    expect(challenges).toHaveLength(1);
+    expect(challenges[0].challenge).toEqual([challenge, votePublication, comment]);
+  });
+
+  it('routes challenge cancellation to the current usePublishVote abandonPublish', async () => {
+    await act(async () => {
+      await testState.lastOptions?.onChallenge({ challenges: [] }, { vote: 1 });
+    });
+
+    const previousAbandonPublish = testState.abandonPublish;
+    const nextAbandonPublish = vi.fn().mockResolvedValue(undefined);
+    testState.abandonPublish = nextAbandonPublish;
+    act(() => root.render(createElement(HookHarness)));
+
+    await act(async () => {
+      await useChallengesStore.getState().abandonCurrentChallenge();
+    });
+
+    expect(nextAbandonPublish).toHaveBeenCalledOnce();
+    expect(previousAbandonPublish).not.toHaveBeenCalled();
+    expect(useChallengesStore.getState().challenges).toHaveLength(0);
+  });
+});

--- a/src/hooks/use-publish-vote-with-challenge-abandon.ts
+++ b/src/hooks/use-publish-vote-with-challenge-abandon.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Comment, UsePublishVoteOptions, usePublishVote } from '@bitsocial/bitsocial-react-hooks';
+import useChallengesStore from '../stores/use-challenges-store';
+
+/** The voted comment is appended to the challenge so the challenge modal can preview the publication target. */
+const usePublishVoteWithChallengeAbandon = (publishVoteOptions: UsePublishVoteOptions, comment?: Comment) => {
+  const addChallenge = useChallengesStore((state) => state.addChallenge);
+  const abandonPublishRef = useRef<(() => Promise<void>) | undefined>(undefined);
+  const abandonCurrentPublish = useCallback(async () => {
+    await abandonPublishRef.current?.();
+  }, []);
+
+  const publishOptionsWithAbandon = useMemo(
+    () => ({
+      ...publishVoteOptions,
+      onChallenge: async (...args: any[]) => {
+        addChallenge([...args, comment], abandonCurrentPublish);
+      },
+    }),
+    [abandonCurrentPublish, addChallenge, comment, publishVoteOptions],
+  );
+
+  const publishResult = usePublishVote(publishOptionsWithAbandon);
+  useEffect(() => {
+    abandonPublishRef.current = publishResult.abandonPublish;
+  }, [publishResult.abandonPublish]);
+
+  return publishResult;
+};
+
+export default usePublishVoteWithChallengeAbandon;

--- a/src/hooks/use-upvote.ts
+++ b/src/hooks/use-upvote.ts
@@ -1,11 +1,10 @@
 import { useMemo } from 'react';
-import { ChallengeVerification, Comment, usePublishVote, useAccountVote } from '@bitsocial/bitsocial-react-hooks';
-import useChallengesStore from '../stores/use-challenges-store';
+import { ChallengeVerification, Comment, useAccountVote } from '@bitsocial/bitsocial-react-hooks';
+import usePublishVoteWithChallengeAbandon from './use-publish-vote-with-challenge-abandon';
 import { alertChallengeVerificationFailed } from '../lib/utils/challenge-utils';
 import { getCommentCommunityAddress } from '../lib/utils/comment-utils';
 
 const useUpvote = (comment: Comment): [boolean, () => void] => {
-  const { addChallenge } = useChallengesStore();
   const { vote } = useAccountVote({ commentCid: comment?.cid });
 
   const publishVoteOptions = useMemo(
@@ -13,12 +12,6 @@ const useUpvote = (comment: Comment): [boolean, () => void] => {
       commentCid: comment?.cid,
       vote: vote !== 1 ? 1 : 0,
       communityAddress: getCommentCommunityAddress(comment),
-      onChallenge: (...args: any) => {
-        return new Promise<void>((resolve) => {
-          addChallenge([...args, comment]);
-          resolve();
-        });
-      },
       onChallengeVerification: (challengeVerification: ChallengeVerification, publication: any) =>
         new Promise<void>((resolve) => {
           alertChallengeVerificationFailed(challengeVerification, publication);
@@ -29,9 +22,9 @@ const useUpvote = (comment: Comment): [boolean, () => void] => {
         alert(error.message);
       },
     }),
-    [comment, vote, addChallenge],
+    [comment, vote],
   );
-  const { publishVote } = usePublishVote(publishVoteOptions);
+  const { publishVote } = usePublishVoteWithChallengeAbandon(publishVoteOptions, comment);
 
   return [vote === 1, publishVote];
 };

--- a/src/lib/utils/view-utils.test.ts
+++ b/src/lib/utils/view-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getAboutLink, isCommunitiesDirectoryAboutView, isCommunitiesDirectoryView } from './view-utils';
+import { getAboutLink, getPendingPostKey, getPendingPostRedirect, isCommunitiesDirectoryAboutView, isCommunitiesDirectoryView } from './view-utils';
 
 describe('isCommunitiesDirectoryView', () => {
   it('matches the directory index and individual directories only', () => {
@@ -21,5 +21,40 @@ describe('directory about views', () => {
   it('links the directory index and candidate list to their own mobile sidebar views', () => {
     expect(getAboutLink('/communities/directories', {})).toBe('/communities/directories/about');
     expect(getAboutLink('/communities/directories/askseedit', { directoryCode: 'askseedit' })).toBe('/communities/directories/askseedit/about');
+  });
+});
+
+describe('getPendingPostRedirect', () => {
+  const postA = getPendingPostKey({ timestamp: 1000, communityAddress: 'example.bso' });
+  const postB = getPendingPostKey({ timestamp: 2000, communityAddress: 'example.bso' });
+
+  it('identifies a pending post only once it has a timestamp', () => {
+    expect(getPendingPostKey(undefined)).toBeUndefined();
+    expect(getPendingPostKey({})).toBeUndefined();
+    expect(postA).toBe('example.bso:1000');
+  });
+
+  it('keeps rendering a valid pending post and a regular post route', () => {
+    expect(getPendingPostRedirect({}, { accountCommentIndex: '1', key: postA }, true)).toBeUndefined();
+    expect(getPendingPostRedirect({ accountCommentIndex: '1', key: postA }, { accountCommentIndex: '1', key: postA }, true)).toBeUndefined();
+    expect(getPendingPostRedirect({}, {}, true)).toBeUndefined();
+  });
+
+  it('goes back when the rendered pending post is deleted and the index becomes invalid', () => {
+    expect(getPendingPostRedirect({ accountCommentIndex: '1', key: postA }, { accountCommentIndex: '1', key: undefined }, false)).toBe('back');
+  });
+
+  it('goes back when a later account comment shifts into the rendered index', () => {
+    expect(getPendingPostRedirect({ accountCommentIndex: '0', key: postA }, { accountCommentIndex: '0', key: postB }, true)).toBe('back');
+  });
+
+  it('shows not found for an invalid index that was never rendered', () => {
+    expect(getPendingPostRedirect({}, { accountCommentIndex: '99', key: undefined }, false)).toBe('not-found');
+    expect(getPendingPostRedirect({ accountCommentIndex: '1', key: postA }, { accountCommentIndex: '99', key: undefined }, false)).toBe('not-found');
+  });
+
+  it('does not treat a rendered index without a comment key as rendered', () => {
+    expect(getPendingPostRedirect({ accountCommentIndex: '1', key: undefined }, { accountCommentIndex: '1', key: postA }, true)).toBeUndefined();
+    expect(getPendingPostRedirect({ accountCommentIndex: '1', key: undefined }, { accountCommentIndex: '1', key: undefined }, false)).toBe('not-found');
   });
 });

--- a/src/lib/utils/view-utils.ts
+++ b/src/lib/utils/view-utils.ts
@@ -1,3 +1,4 @@
+import { type Comment } from '@bitsocial/bitsocial-react-hooks';
 import { isDirectoryCode } from './directory-codes';
 import { DIRECTORY_INDEX_PATH, getDirectoryAboutPath } from './community-route-utils';
 
@@ -114,6 +115,30 @@ export const isModView = (pathname: string): boolean => {
 
 export const isPendingPostView = (pathname: string, params: ParamsType): boolean => {
   return pathname === `/profile/${params.accountCommentIndex}`;
+};
+
+export interface RenderedPendingPost {
+  accountCommentIndex?: string;
+  key?: string;
+}
+
+// a pending account comment has no cid yet; its publish timestamp and community identify it across
+// the reindexing that happens when an earlier account comment is deleted
+export const getPendingPostKey = (accountComment?: Comment): string | undefined =>
+  accountComment?.timestamp === undefined ? undefined : `${accountComment.communityAddress ?? ''}:${accountComment.timestamp}`;
+
+// abandoning a pending post deletes its account comment, so the post page that rendered it must go back
+// instead of showing not found, also when a later account comment shifted into the same index
+export const getPendingPostRedirect = (
+  rendered: RenderedPendingPost,
+  current: RenderedPendingPost,
+  isValidAccountCommentIndex: boolean,
+): 'back' | 'not-found' | undefined => {
+  const wasRenderedHere = rendered.key !== undefined && rendered.accountCommentIndex === current.accountCommentIndex;
+  if (isValidAccountCommentIndex && !(wasRenderedHere && rendered.key !== current.key)) {
+    return undefined;
+  }
+  return wasRenderedHere ? 'back' : 'not-found';
 };
 
 export const isPostPageView = (pathname: string, params: ParamsType): boolean => {

--- a/src/views/post-page/post-page.tsx
+++ b/src/views/post-page/post-page.tsx
@@ -266,11 +266,21 @@ const PostPage = () => {
       accountComments?.length > 0 &&
       parseInt(accountCommentIndex) < accountComments.length);
 
+  // a pending post that was already rendered disappears when its publication is abandoned during the
+  // challenge, because abandoning deletes the account comment; go back instead of showing not found
+  const renderedAccountCommentIndexRef = useRef<string | undefined>(undefined);
+
   useEffect(() => {
-    if (!isValidAccountCommentIndex) {
-      navigate('/not-found', { replace: true });
+    if (isValidAccountCommentIndex) {
+      renderedAccountCommentIndexRef.current = accountCommentIndex;
+      return;
     }
-  }, [isValidAccountCommentIndex, navigate]);
+    if (renderedAccountCommentIndexRef.current === accountCommentIndex) {
+      navigate(-1);
+      return;
+    }
+    navigate('/not-found', { replace: true });
+  }, [accountCommentIndex, isValidAccountCommentIndex, navigate]);
 
   const accountComment = useOptionalAccountComment(commentIndex);
   const pendingPost = accountComment;

--- a/src/views/post-page/post-page.tsx
+++ b/src/views/post-page/post-page.tsx
@@ -6,7 +6,7 @@ import findTopParentCidOfReply from '../../lib/utils/cid-utils';
 import { getCommentCommunityAddress } from '../../lib/utils/comment-utils';
 import { sortRepliesByBest } from '../../lib/utils/post-utils';
 import { getCanonicalCommunityPostRedirectPath, getCommunityPostPath, resolveCommunityRouteAddress } from '../../lib/utils/community-route-utils';
-import { isPendingPostView, isPostContextView } from '../../lib/utils/view-utils';
+import { getPendingPostKey, getPendingPostRedirect, isPendingPostView, isPostContextView, RenderedPendingPost } from '../../lib/utils/view-utils';
 import useContentOptionsStore from '../../stores/use-content-options-store';
 import useFeedResetStore from '../../stores/use-feed-reset-store';
 import { useIsNsfwCommunity } from '../../hooks/use-is-nsfw-community';
@@ -266,24 +266,28 @@ const PostPage = () => {
       accountComments?.length > 0 &&
       parseInt(accountCommentIndex) < accountComments.length);
 
+  const accountComment = useOptionalAccountComment(commentIndex);
+  const pendingPost = accountComment;
+
   // a pending post that was already rendered disappears when its publication is abandoned during the
   // challenge, because abandoning deletes the account comment; go back instead of showing not found
-  const renderedAccountCommentIndexRef = useRef<string | undefined>(undefined);
+  const pendingPostKey = getPendingPostKey(accountComment);
+  const renderedPendingPostRef = useRef<RenderedPendingPost>({});
 
   useEffect(() => {
-    if (isValidAccountCommentIndex) {
-      renderedAccountCommentIndexRef.current = accountCommentIndex;
+    const current = { accountCommentIndex, key: pendingPostKey };
+    const redirect = getPendingPostRedirect(renderedPendingPostRef.current, current, isValidAccountCommentIndex);
+    if (!redirect) {
+      renderedPendingPostRef.current = current;
       return;
     }
-    if (renderedAccountCommentIndexRef.current === accountCommentIndex) {
+    if (redirect === 'back') {
       navigate(-1);
       return;
     }
     navigate('/not-found', { replace: true });
-  }, [accountCommentIndex, isValidAccountCommentIndex, navigate]);
+  }, [accountCommentIndex, isValidAccountCommentIndex, navigate, pendingPostKey]);
 
-  const accountComment = useOptionalAccountComment(commentIndex);
-  const pendingPost = accountComment;
   const pendingPostCommunityAddress = getCommentCommunityAddress(pendingPost);
 
   // in pending post route, redirect to post page route when post is published (cid is defined)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1378,9 +1378,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bitsocial/bitsocial-react-hooks@npm:0.1.42":
-  version: 0.1.42
-  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.42"
+"@bitsocial/bitsocial-react-hooks@npm:0.1.44":
+  version: 0.1.44
+  resolution: "@bitsocial/bitsocial-react-hooks@npm:0.1.44"
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.10"
     "@pkcprotocol/pkc-js": "npm:0.0.88"
@@ -1399,7 +1399,7 @@ __metadata:
     zustand: "npm:4.5.7"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/729c45ba038fc0be48d8e7eaea50a1ce93948f0beaae679924be6f3b1c19215d77a096bb57a03ed2a64d1ce05c298c98aa1fbb2c4f73cf48cad9dbeb3dc73f1a
+  checksum: 10c0/271eaf5b58c55477b1efc6d1e65038fcb7c09c6e28201af3ccb3beae6ff31b1175cef4fd5b3af583b19a5525f8a8256bc933a98833a27b55a49e46a06494ecef
   languageName: node
   linkType: hard
 
@@ -19691,7 +19691,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "seedit@workspace:."
   dependencies:
-    "@bitsocial/bitsocial-react-hooks": "npm:0.1.42"
+    "@bitsocial/bitsocial-react-hooks": "npm:0.1.44"
     "@bitsocial/bso-resolver": "npm:0.0.10"
     "@capacitor/android": "npm:7.4.5"
     "@capacitor/app": "npm:7.0.1"


### PR DESCRIPTION
## Summary

- Pin `@bitsocial/bitsocial-react-hooks` to `0.1.44`, which adds `abandonPublish()` to the `usePublishVote` result.
- Add `usePublishVoteWithChallengeAbandon`, mirroring `usePublishCommentWithChallengeAbandon`: it wraps `usePublishVote`, registers the challenge with the voted comment appended (the challenge modal previews it), and routes the modal's abandon action to the hook's `abandonPublish`, which stops the pending vote publication and restores the account vote the optimistic publish replaced.
- `useUpvote` / `useDownvote` use the wrapper instead of wiring `onChallenge` themselves.
- Post page: when a pending post that was already rendered disappears because its publication was abandoned from its own page, navigate back instead of redirecting to `not-found`. Direct visits to an invalid pending index still go to `not-found`.
- Add a unit test for the wrapper (challenge entry shape, abandon routing to the latest `abandonPublish`).

## Verification

- `yarn lint`: pass
- `corepack yarn exec vitest run --maxWorkers=2` on the wrapper test and `use-publish-reply.test.tsx`: 5 passed
- `yarn build`: pass
- `yarn doctor`: no new diagnostics on the changed hunks; the only hits on the touched files are the pre-existing repo-wide "redundant manual memoization" warning that the mirrored comment wrapper and the vote hooks already trigger
- `yarn type-check`: fails on master-only code (`src/components/topbar/topbar.tsx` reading `timeFilterNames` from `useTimeFilter`, which no longer returns it); those files are not touched here and CI does not run `tsc`. Reported separately.
- Browser verification: not run. This change is behavior-only wiring on top of the library API with no visual UI change; the challenge modal and vote arrows render unchanged. Reproducing the abandon flow needs a community that issues a challenge, so the wrapper behavior is covered by the unit test instead.

Closes #837

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vote publication and challenge abandon wiring plus profile pending-post navigation; wrong abandon routing could leave stale votes or bad redirects, but behavior is covered by new tests and mirrors an existing comment-publish pattern.
> 
> **Overview**
> Upgrades `@bitsocial/bitsocial-react-hooks` to **0.1.44** so vote publishing exposes **`abandonPublish`**, then centralizes challenge handling in a new **`usePublishVoteWithChallengeAbandon`** hook (same idea as the comment publish wrapper). **`useUpvote`** and **`useDownvote`** now use that wrapper instead of inline **`onChallenge`** + **`useChallengesStore`**: challenges still append the voted comment for the modal preview, and abandoning the challenge calls the hook’s current **`abandonPublish`** so the pending vote is cancelled and optimistic state is restored.
> 
> On the **pending profile post** route, **`getPendingPostKey`** / **`getPendingPostRedirect`** track which pending account comment was shown; when abandon (or reindexing) removes or replaces it, **`post-page`** **`navigate(-1)`** instead of **`/not-found`**, while bad direct URLs still go to not found. Unit tests cover the vote wrapper and redirect rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8824358ad65a31566e0a9994b2e2879ccf69f97f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Voting challenges now retain the associated comment for modal previews.
  - Abandoning a vote challenge now correctly returns to the previously viewed post.
  - Improved pending-post navigation, preventing incorrect not-found redirects when comments are removed or reordered.

- **Chores**
  - Updated the React hooks package to a newer compatible version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->